### PR TITLE
Editorial: Add missing nullability

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,7 +324,7 @@
       <pre class="idl">
         partial interface CaptureController {
           constructor();
-          Promise&lt;undefined&gt; forwardWheel(HTMLElement element);
+          Promise&lt;undefined&gt; forwardWheel(HTMLElement? element);
         };
       </pre>
       <dl data-link-for="CaptureController" data-dfn-for="CaptureController" class="methods">


### PR DESCRIPTION
The steps of the algorithm attached to `forwardWheel(element)` explicitly discuss the possibility of `element` being `null`, which clearly indicates that the missing `?` in the WebIDL is an editorial error.