### PR TITLE
Clarify where wheel events fire

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,14 +538,14 @@
                 [=this=].{{CaptureController/[[forwardWheelElement]]}}.
               </li>
               <li>
-                [=Fire an event=] named `"wheel"` using {{WheelEvent}} with the {{MouseEvent/x}}
-                attribute initialized to |scaledX|, the {{MouseEvent/y}} attribute initialized to
-                |scaledY|, the {{WheelEvent/deltaX}} attribute initialized to
-                |event|.{{WheelEvent/deltaX}} and the {{WheelEvent/deltaY}} attribute initialized to
-                |event|.{{WheelEvent/deltaY}}, at |controller|.<a
-                  data-cite="!screen-capture/#dfn-source"
-                  >[[\Source]]</a
-                >'s viewport.
+                [=Queue a global task=] on the [=user interaction task source=] of
+                |controller|.[[\Source]]'s current realm, given that
+                <a data-cite="HTML#concept-realm-global">realm's global object</a>, to [=fire an
+                event=] named <code>"wheel"</code> using {{WheelEvent}} with the {{MouseEvent//x}}
+                attribute initialized to |scaledX|, the {{MouseEvent//y}} attribute initialized to
+                |scaledY|, the {{WheelEvent/deltaX}} attribute initialized to |event|.|deltaX| and
+                the {{WheelEvent/deltaY}} attribute initialized to |event|.|deltaY|, at the
+                <a data-cite="uievents#topmost-event-target">topmost event target</a>.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Fixes #51.

Thanks @tidoust for filing the issue and suggesting the fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-surface-control/pull/56.html" title="Last updated on Jan 23, 2025, 9:26 AM UTC (b46b621)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-surface-control/56/09ac7fe...b46b621.html" title="Last updated on Jan 23, 2025, 9:26 AM UTC (b46b621)">Diff</a>