### PR TITLE
Fix missed locations with capturedzoomlevelchange

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,11 +234,11 @@
           <dd>
             <p>
               An [=event handler IDL attribute=] whose [=event handler event type=] is
-              `capturedzoomlevelchange`.
+              `zoomlevelchange`.
             </p>
             <p>
               Given a {{CaptureController}} |controller|, the user agent MUST [=fire an event=]
-              named `capturedzoomlevelchange` at |controller| whenever |controller|.<a
+              named `zoomlevelchange` at |controller| whenever |controller|.<a
                 data-cite="!screen-capture/#dfn-source"
                 >[[\Source]]</a
               >'s [=zoom level=] changes.


### PR DESCRIPTION
Fix #63.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-surface-control/pull/64.html" title="Last updated on Jan 24, 2025, 12:27 PM UTC (82952e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-surface-control/64/093146c...82952e5.html" title="Last updated on Jan 24, 2025, 12:27 PM UTC (82952e5)">Diff</a>